### PR TITLE
TimerTests: Initial test setup for the Timer class.

### DIFF
--- a/src/game/Timer.java
+++ b/src/game/Timer.java
@@ -1,6 +1,7 @@
 package game;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 /**
  * Timer class implementation based off the UML Diagram
@@ -36,10 +37,8 @@ public class Timer {
     }
 
     public boolean isTimeUp() {
-        if(endTime == null) {
-            return LocalDateTime.now().isAfter(endTime);
-        }
-        return false;
+        LocalDateTime now = LocalDateTime.now();
+        return now.isAfter(startTime.plusSeconds(this.duration));
     }
 
     public LocalDateTime getStartTime() {

--- a/src/tests/TimerTests.java
+++ b/src/tests/TimerTests.java
@@ -1,0 +1,81 @@
+import game.Timer;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.ZoneOffset;
+
+public class TimerTests {
+    @Test
+    public void timer_constructor() {
+        for (int i = 0; i < 10000; i += 500) {
+            Timer timer = new Timer(i);
+            Assertions.assertEquals(i, timer.getDuration());
+        }
+    }
+
+    @Test
+    public void timer_startStopTimer_noDelay() {
+        Timer timer = new Timer(100);
+        Assertions.assertNull(timer.getStartTime());
+
+        timer.startTimer();
+        Assertions.assertNotNull(timer.getStartTime());
+        long start = timer.getStartTime().toEpochSecond(ZoneOffset.UTC);
+
+        timer.stopTimer();
+        Assertions.assertNotNull(timer.getStartTime());
+        long end = timer.getEndTime().toEpochSecond(ZoneOffset.UTC);
+
+        Assertions.assertEquals(start, end, 1);                 // accept differences within 1 second difference for this test
+        Assertions.assertTrue(end > start);
+    }
+
+    @Test
+    public void timer_startStopTimer_delay() throws InterruptedException {
+        Timer timer = new Timer(100);
+        Assertions.assertNull(timer.getStartTime());
+
+        timer.startTimer();
+        Assertions.assertNotNull(timer.getStartTime());
+        long start = timer.getStartTime().toEpochSecond(ZoneOffset.UTC);
+
+        Thread.sleep(3000);                                         // wait ~3 seconds
+
+        timer.stopTimer();
+        long end = timer.getEndTime().toEpochSecond(ZoneOffset.UTC);
+        Assertions.assertEquals(start, end - 3000, 1);
+        Assertions.assertTrue(end > start);
+    }
+
+    @Test
+    public void timer_reset() {
+        Timer timer = new Timer(100);
+        timer.startTimer();
+        Assertions.assertNotNull(timer.getStartTime());
+        timer.stopTimer();
+        Assertions.assertNotNull(timer.getEndTime());
+
+        timer.resetTimer();
+        Assertions.assertNull(timer.getStartTime());
+        Assertions.assertNull(timer.getEndTime());
+    }
+
+    @Test
+    public void timer_getElapsedTime() throws InterruptedException {
+        Timer timer = new Timer(100);
+        timer.startTimer();
+        Assertions.assertNotNull(timer.getStartTime());
+        Thread.sleep(1000);
+        timer.stopTimer();
+        Assertions.assertNotNull(timer.getEndTime());
+        Assertions.assertEquals(1, timer.getElapsedTime());
+    }
+
+    @Test
+    public void timer_isTimeUp() throws InterruptedException {
+        Timer timer = new Timer(1);
+        timer.startTimer();
+        Thread.sleep(1500);
+        Assertions.assertTrue(timer.isTimeUp());
+    }
+}

--- a/src/tests/TimerTests.java
+++ b/src/tests/TimerTests.java
@@ -1,74 +1,77 @@
+package tests;
+
 import game.Timer;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 import java.time.ZoneOffset;
+
+import static org.junit.Assert.*;
 
 public class TimerTests {
     @Test
     public void timer_constructor() {
         for (int i = 0; i < 10000; i += 500) {
             Timer timer = new Timer(i);
-            Assertions.assertEquals(i, timer.getDuration());
+            assertEquals(i, timer.getDuration());
         }
     }
 
     @Test
     public void timer_startStopTimer_noDelay() {
         Timer timer = new Timer(100);
-        Assertions.assertNull(timer.getStartTime());
+        assertNull(timer.getStartTime());
 
         timer.startTimer();
-        Assertions.assertNotNull(timer.getStartTime());
+        assertNotNull(timer.getStartTime());
         long start = timer.getStartTime().toEpochSecond(ZoneOffset.UTC);
 
         timer.stopTimer();
-        Assertions.assertNotNull(timer.getStartTime());
+        assertNotNull(timer.getStartTime());
         long end = timer.getEndTime().toEpochSecond(ZoneOffset.UTC);
 
-        Assertions.assertEquals(start, end, 1);                 // accept differences within 1 second difference for this test
-        Assertions.assertTrue(end > start);
+        assertEquals(start, end, 1);                 // accept differences within 1 second difference for this test
+        assertTrue(end > start);
     }
 
     @Test
     public void timer_startStopTimer_delay() throws InterruptedException {
         Timer timer = new Timer(100);
-        Assertions.assertNull(timer.getStartTime());
+        assertNull(timer.getStartTime());
 
         timer.startTimer();
-        Assertions.assertNotNull(timer.getStartTime());
+        assertNotNull(timer.getStartTime());
         long start = timer.getStartTime().toEpochSecond(ZoneOffset.UTC);
 
         Thread.sleep(3000);                                         // wait ~3 seconds
 
         timer.stopTimer();
         long end = timer.getEndTime().toEpochSecond(ZoneOffset.UTC);
-        Assertions.assertEquals(start, end - 3000, 1);
-        Assertions.assertTrue(end > start);
+        assertEquals(start, end - 3000, 1);
+        assertTrue(end > start);
     }
 
     @Test
     public void timer_reset() {
         Timer timer = new Timer(100);
         timer.startTimer();
-        Assertions.assertNotNull(timer.getStartTime());
+        assertNotNull(timer.getStartTime());
         timer.stopTimer();
-        Assertions.assertNotNull(timer.getEndTime());
+        assertNotNull(timer.getEndTime());
 
         timer.resetTimer();
-        Assertions.assertNull(timer.getStartTime());
-        Assertions.assertNull(timer.getEndTime());
+        assertNull(timer.getStartTime());
+        assertNull(timer.getEndTime());
     }
 
     @Test
     public void timer_getElapsedTime() throws InterruptedException {
         Timer timer = new Timer(100);
         timer.startTimer();
-        Assertions.assertNotNull(timer.getStartTime());
+        assertNotNull(timer.getStartTime());
         Thread.sleep(1000);
         timer.stopTimer();
-        Assertions.assertNotNull(timer.getEndTime());
-        Assertions.assertEquals(1, timer.getElapsedTime());
+        assertNotNull(timer.getEndTime());
+        assertEquals(1, timer.getElapsedTime());
     }
 
     @Test
@@ -76,6 +79,6 @@ public class TimerTests {
         Timer timer = new Timer(1);
         timer.startTimer();
         Thread.sleep(1500);
-        Assertions.assertTrue(timer.isTimeUp());
+        assertTrue(timer.isTimeUp());
     }
 }


### PR DESCRIPTION
Not verified yet due to errors elsewhere preventing test running.

Due to the nature of this class, some of the tests rely on actual time having passed. This unfortunately may cause the JUnit test suite to take longer than normal. Im not sure if there is a reasonable workaround for this.